### PR TITLE
Fixes broken links to Block scope katas

### DIFF
--- a/src/for-offline/grouped-metadata.json
+++ b/src/for-offline/grouped-metadata.json
@@ -77,7 +77,7 @@
         {
           "name": "`let` declaration",
           "description": "`let` restricts the scope of the variable to the current block.",
-          "path": "block-scope/let",
+          "path": "block-scoping/let",
           "level": "TBD",
           "requiresKnowledgeFrom": [],
           "groupName": "Block scope",
@@ -86,7 +86,7 @@
         {
           "name": "`const` declaration",
           "description": "`const` is like `let` plus read-only.",
-          "path": "block-scope/const",
+          "path": "block-scoping/const",
           "level": "TBD",
           "requiresKnowledgeFrom": [
             7


### PR DESCRIPTION
master points to `block-scope` instead of the existing `block-scoping`.