### PR TITLE
Preventing edit bubbles from showing through

### DIFF
--- a/src/style.css
+++ b/src/style.css
@@ -47,6 +47,7 @@ footer {
 }
   .group .kata:hover .details {
     display: block;
+    z-index: 1;
   }
 
 .notification-bubble {
@@ -92,3 +93,4 @@ footer {
   .workshop-banner .close-button-container {
     text-align: right;
   }
+  


### PR DESCRIPTION
The "edit" bubbles show through the details boxes that are visible on hover. A simple z-index did the trick :)